### PR TITLE
Fixes to make Memfault work for ProGlove devices

### DIFF
--- a/ports/zephyr/v2.4/memfault_fault_handler.c
+++ b/ports/zephyr/v2.4/memfault_fault_handler.c
@@ -107,7 +107,9 @@ void memfault_zephyr_z_fatal_error(void) {
 MEMFAULT_WEAK
 MEMFAULT_NORETURN
 void memfault_platform_reboot(void) {
+#if !CONFIG_LOG_BACKEND_RTT
   memfault_platform_halt_if_debugging();
+#endif
 
 #if CONFIG_MEMFAULT_ZEPHYR_FATAL_HANDLER
   memfault_zephyr_z_fatal_error();

--- a/ports/zephyr/v2.4/memfault_fault_handler.c
+++ b/ports/zephyr/v2.4/memfault_fault_handler.c
@@ -115,6 +115,9 @@ void memfault_platform_reboot(void) {
   memfault_zephyr_z_fatal_error();
 #endif
 
+  /* Notify logging backends to synchronously empty buffers before rebooting */
+  log_panic();
+
   sys_arch_reboot(0);
   CODE_UNREACHABLE;
 }


### PR DESCRIPTION
## Changes:

### Check whether the RTT backend is enabled and skip the breakpoint in this case

If the RTT logging backend is used and a JLink probe is connected, the
DHCSR register is set which indicates to the memfault sdk that a
debugger is attached, even though only one-way logging is used.
Execution halts at a breakpoint and the reboot is never reached.

This is a temporary fix which might be solved by a dedicated config
option upstream.

### Flush logging backends before rebooting at fault

When deferred logging is used, the reboot after fault currently happens
before the logging backends are flushed and therefore information about
the fault background are lost.

Add a call to log_panic() before the reboot to synchonously notify and
flush all logging backends before continuing to the reboot.